### PR TITLE
Feature/fixing crt path not found

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -218,6 +218,7 @@ personio/mp-rest/url: "https://api.personio.de"
 personio/mp-rest/trustStorePassword: "PWD_OF_TRUSTSTORE_FILE"
 personio/mp-rest/trustStoreType: "TRUSTSTORE_TYPE"
 personio/mp-rest/trustStore: "FQN_OF_TRUSTSTORE_FILE"
+personio/mp-rest/scope: "javax.enterprise.context.RequestScoped"
 ----
 
 TIP: See link:https://quarkus.io/guides/opentracing[quarkus-opentracing]

--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,10 @@
         <!-- The revision property for CI-friendly builds -->
         <revision>1.0.0</revision>
 
-        <quarkus-plugin.version>1.3.2.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.6.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.3.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.6.0.Final</quarkus.platform.version>
 
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
 


### PR DESCRIPTION
#10 Fixing certificate handshake path not found, which was fixed in the new quarkus version 1.6.0 ([Issue-9713](https://github.com/quarkusio/quarkus/issues/9713))